### PR TITLE
Improves cmake workflow and adds installation instructions

### DIFF
--- a/lib/v2.0/C++/CMakeLists.txt
+++ b/lib/v2.0/C++/CMakeLists.txt
@@ -2,10 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 project(pprzlink++)
 
 set(CMAKE_CXX_STANDARD 17)
+include(GNUInstallDirs)
 
-include_directories(ivy-c++)
-include_directories(pprzlink)
-include_directories(pprzlink/exceptions)
 
 find_package(tinyxml2 REQUIRED)
 find_package(Boost COMPONENTS system)
@@ -30,11 +28,14 @@ set(SOURCE
         pprzlink/MessageFieldTypes.cpp
         pprzlink/PprzTransport.cpp)
 
-set(HEADERS
+set(HEADERS_IVY
         ivy-c++/Ivy.h
         ivy-c++/IvyApplication.h
         ivy-c++/IvyCallback.h
-        pprzlink/exceptions/pprzlink_exception.h
+)
+set(HEADERS_PPRZLINK_EXCEPTION
+        pprzlink/exceptions/pprzlink_exception.h)
+set(HEADERS_PPRZLINK
         pprzlink/BoostSerialPortDevice.h
         pprzlink/Device.h
         pprzlink/FieldValue.h
@@ -50,7 +51,7 @@ set(HEADERS
 
 add_library(pprzlink++_static ${SOURCE})
 add_library(pprzlink++ SHARED ${SOURCE})
-
+#set_target_properties(pprzlink++ PROPERTIES PUBLIC_HEADER "${HEADERS_IVY};${HEADERS_PPRZLINK_EXCEPTION};${HEADERS_PPRZLINK}")
 target_link_libraries(${PROJECT_NAME}
         #${Boost_LIBRARIES}
         ${IVY_LIB}
@@ -58,5 +59,20 @@ target_link_libraries(${PROJECT_NAME}
         Boost::system
         )
 
-install(TARGETS pprzlink++ DESTINATION lib)
-install(FILES ${HEADERS} DESTINATION include)
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Config 
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(FILES ${HEADERS_IVY} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ivy-c++")
+install(FILES ${HEADERS_PPRZLINK} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/pprzlink")
+install(FILES ${HEADERS_PPRZLINK_EXCEPTION} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/pprzlink/exceptions")
+
+export(TARGETS
+        ${PROJECT_NAME}
+        FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+)
+install(EXPORT ${PROJECT_NAME}Config DESTINATION "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/cmake")

--- a/lib/v2.0/C++/README.md
+++ b/lib/v2.0/C++/README.md
@@ -1,0 +1,6 @@
+# Installation example
+1. `mkdir build && cd build`
+2. `export tinyxml2_DIR=/path/to/tinyxml2` (might not be needed depending on your install)
+3. `cmake ..` (use `ccmake ..` to easily configure install path `CMAKE_INSTALL_PREFIX` or other parameters)
+4. `make -j8`
+5. `make install` (`sudo make install` is probably required if installing system wide)


### PR DESCRIPTION
Removes unnecessary include_directories
Export pprzlink++Config.cmake allowing project using cmake to find pprzlink++ library more easily
Adds installation of necessary public header files while respecting the hierarchy
Adds installation instructions example
